### PR TITLE
Port GObject based methods to GLib

### DIFF
--- a/CantaBichos/CantaBichos.py
+++ b/CantaBichos/CantaBichos.py
@@ -3,7 +3,7 @@
 
 import os
 import gtk
-import gobject
+from gi.repository import GLib
 
 from player import Player
 
@@ -39,7 +39,7 @@ class CantaBichos(gtk.Table):
         self.show_all()
 
     def __realize(self, widget):
-        gobject.idle_add(self.__dialog_run)
+        GLib.idle_add(self.__dialog_run)
 
     def __dialog_run(self):
         dialog = Dialog(parent=self.get_toplevel(),
@@ -124,13 +124,13 @@ class Button(gtk.EventBox):
 
     def __size_request(self, widget, event):
         rect = self.get_allocation()
-        gobject.idle_add(self.imagen.set_from_pixbuf,
+        GLib.idle_add(self.imagen.set_from_pixbuf,
             gtk.gdk.pixbuf_new_from_file_at_size(
             self.image_path, rect.width, -1))
 
     def __redraw(self, widget, event):
         rect = self.get_allocation()
-        gobject.idle_add(self.imagen.set_from_pixbuf,
+        GLib.idle_add(self.imagen.set_from_pixbuf,
             gtk.gdk.pixbuf_new_from_file_at_size(
             self.image_path, rect.width, -1))
 
@@ -153,4 +153,4 @@ class Dialog(gtk.Dialog):
         self.vbox.pack_start(label, True, True, 0)
         self.vbox.show_all()
 
-        gobject.timeout_add(3000, self.destroy)
+        GLib.timeout_add(3000, self.destroy)

--- a/CantaBichos/player.py
+++ b/CantaBichos/player.py
@@ -6,29 +6,31 @@
 #   Uruguay
 
 import os
-import gobject
+import gi
+gi.require_version('Gst', '1.0')
+from gi.repository import GObject
 import gst
 
-gobject.threads_init()
+GObject.threads_init()
 
 
-class Player(gobject.GObject):
+class Player(GObject.GObject):
 
     __gsignals__ = {
-    "endfile": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, [])}
+    "endfile": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, [])}
 
     def __init__(self):
 
-        gobject.GObject.__init__(self)
+        GObject.GObject.__init__(self)
 
         self.player = None
         self.bus = None
 
-        self.player = gst.element_factory_make("playbin2", "player")
+        self.player = Gst.element_factory_make("playbin2", "player")
 
-        fakesink = gst.element_factory_make("fakesink", "fakesink")
-        autoaudio = gst.element_factory_make("autoaudiosink", "autoaudio")
+        fakesink = Gst.element_factory_make("fakesink", "fakesink")
+        autoaudio = Gst.element_factory_make("autoaudiosink", "autoaudio")
         self.player.set_property('video-sink', fakesink)
         self.player.set_property('audio-sink', autoaudio)
 
@@ -39,29 +41,29 @@ class Player(gobject.GObject):
         self.bus.connect('sync-message', self.__sync_message)
 
     def __sync_message(self, bus, message):
-        if message.type == gst.MESSAGE_LATENCY:
+        if message.type == Gst.MESSAGE_LATENCY:
             self.player.recalculate_latency()
 
-        elif message.type == gst.MESSAGE_ERROR:
+        elif message.type == Gst.MESSAGE_ERROR:
             err, debug = message.parse_error()
             pass
 
     def __on_mensaje(self, bus, message):
-        if message.type == gst.MESSAGE_EOS:
+        if message.type == Gst.MESSAGE_EOS:
             self.emit("endfile")
 
-        elif message.type == gst.MESSAGE_ERROR:
+        elif message.type == Gst.MESSAGE_ERROR:
             err, debug = message.parse_error()
             pass
 
     def __play(self):
-        self.player.set_state(gst.STATE_PLAYING)
+        self.player.set_state(Gst.STATE_PLAYING)
 
     def __pause(self):
-        self.player.set_state(gst.STATE_PAUSED)
+        self.player.set_state(Gst.STATE_PAUSED)
 
     def stop(self):
-        self.player.set_state(gst.STATE_NULL)
+        self.player.set_state(Gst.STATE_NULL)
 
     def load(self, uri):
         if not uri:

--- a/CucaraSims/CucaraSims.py
+++ b/CucaraSims/CucaraSims.py
@@ -7,7 +7,8 @@
 
 import os
 import gtk
-import gobject
+from gi.repository import GObject
+from gi.repository import GLib
 
 from Widgets import Widget_Leccion
 from Widgets import Toolbar
@@ -19,12 +20,12 @@ BASE_PATH = os.path.dirname(__file__)
 class CucaraSimsWidget(gtk.HPaned):
 
     __gsignals__ = {
-    "exit": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, []),
-    "set-cursor": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, (gobject.TYPE_PYOBJECT, )),
-    "volumen": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, (gobject.TYPE_FLOAT, ))}
+    "exit": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, []),
+    "set-cursor": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, (GObject.TYPE_PYOBJECT, )),
+    "volumen": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, (GObject.TYPE_FLOAT, ))}
 
     def __init__(self, escenario):
 
@@ -56,7 +57,7 @@ class CucaraSimsWidget(gtk.HPaned):
         self.cursor_root = False
         self.cursor_tipo = False
 
-        gobject.idle_add(self.__config_cursors)
+        GLib.idle_add(self.__config_cursors)
 
     def __volumen_changed(self, widget, valor):
         self.emit('volumen', valor)
@@ -194,10 +195,10 @@ class CucaraSimsWidget(gtk.HPaned):
 class Derecha(gtk.EventBox):
 
     __gsignals__ = {
-    "lectura": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, (gobject.TYPE_STRING, )),
-    "select": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, (gobject.TYPE_PYOBJECT, ))}
+    "lectura": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, (GObject.TYPE_STRING, )),
+    "select": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, (GObject.TYPE_PYOBJECT, ))}
 
     def __init__(self):
 
@@ -253,8 +254,8 @@ class Derecha(gtk.EventBox):
 class ButtonImagen(gtk.EventBox):
 
     __gsignals__ = {
-    "select": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, (gobject.TYPE_STRING, ))}
+    "select": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, (GObject.TYPE_STRING, ))}
 
     def __init__(self, tipo):
 

--- a/CucaraSims/Cucaracha.py
+++ b/CucaraSims/Cucaracha.py
@@ -6,7 +6,7 @@
 #   Uruguay
 
 import os
-import gobject
+from gi.repository import GObject
 import pygame
 from pygame.sprite import Sprite
 import random
@@ -23,23 +23,23 @@ BASE_PATH = os.path.dirname(__file__)
 INDICE_ROTACION = 5
 
 
-class Cucaracha(Sprite, gobject.GObject):
+class Cucaracha(Sprite, GObject.GObject):
 
     __gsignals__ = {
-    #"new-edad": (gobject.SIGNAL_RUN_LAST,
-    #    gobject.TYPE_NONE, (gobject.TYPE_PYOBJECT, )),
-    "muere": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, (gobject.TYPE_PYOBJECT,
-        gobject.TYPE_PYOBJECT)),
-    "muda": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, []),
-    "reproduce": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, (gobject.TYPE_PYOBJECT, ))}
+    #"new-edad": (GObject.SIGNAL_RUN_LAST,
+    #    GObject.TYPE_NONE, (GObject.TYPE_PYOBJECT, )),
+    "muere": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, (GObject.TYPE_PYOBJECT,
+        GObject.TYPE_PYOBJECT)),
+    "muda": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, []),
+    "reproduce": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, (GObject.TYPE_PYOBJECT, ))}
 
     def __init__(self, sexo, ancho, alto, TIME):
 
         Sprite.__init__(self)
-        gobject.GObject.__init__(self)
+        GObject.GObject.__init__(self)
 
         self.acciones = ["camina", "gira", "quieto"]
         self.sexo = sexo

--- a/CucaraSims/Huevos.py
+++ b/CucaraSims/Huevos.py
@@ -6,7 +6,7 @@
 #   Uruguay
 
 import os
-import gobject
+from gi.repository import GObject
 import pygame
 from pygame.sprite import Sprite
 import random
@@ -16,17 +16,17 @@ from Timer import Timer
 BASE_PATH = os.path.dirname(__file__)
 
 
-class Huevo(Sprite, gobject.GObject):
+class Huevo(Sprite, GObject.GObject):
 
     __gsignals__ = {
-    "nacer": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, (gobject.TYPE_PYOBJECT,
-        gobject.TYPE_PYOBJECT))}
+    "nacer": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, (GObject.TYPE_PYOBJECT,
+        GObject.TYPE_PYOBJECT))}
 
     def __init__(self, pos, TIME):
 
         Sprite.__init__(self)
-        gobject.GObject.__init__(self)
+        GObject.GObject.__init__(self)
 
         path = os.path.join(BASE_PATH, "Imagenes", "huevos.png")
         self.imagen = pygame.image.load(path)

--- a/CucaraSims/JAMediaImagenes/ImagePlayer.py
+++ b/CucaraSims/JAMediaImagenes/ImagePlayer.py
@@ -6,17 +6,19 @@
 #   Uruguay
 
 import os
-import gobject
-import gst
+import gi
+from gi.repository import GObject
+gi.require_version('Gst', '1.0')
+from gi.repository import Gst
 
 PR = False
 
 
-class ImagePlayer(gobject.GObject):
+class ImagePlayer(GObject.GObject):
 
     def __init__(self, ventana):
 
-        gobject.GObject.__init__(self)
+        GObject.GObject.__init__(self)
 
         self.ventana = ventana
         self.src_path = ""
@@ -63,17 +65,17 @@ class ImagePlayer(gobject.GObject):
             pass
 
 
-class PlayerBin(gobject.GObject):
+class PlayerBin(GObject.GObject):
 
     def __init__(self, ventana_id, width, height):
 
-        gobject.GObject.__init__(self)
+        GObject.GObject.__init__(self)
 
         self.ventana_id = ventana_id
         self.player = None
         self.bus = None
 
-        self.player = gst.element_factory_make("playbin2", "player")
+        self.player = Gst.element_factory_make("playbin2", "player")
         self.video_bin = Video_Out(width, height)
         self.player.set_property('video-sink', self.video_bin)
 
@@ -83,11 +85,11 @@ class PlayerBin(gobject.GObject):
         self.bus.connect('sync-message', self.__sync_message)
 
     def __sync_message(self, bus, message):
-        if message.type == gst.MESSAGE_ELEMENT:
+        if message.type == Gst.MESSAGE_ELEMENT:
             if message.structure.get_name() == 'prepare-xwindow-id':
                 message.src.set_xwindow_id(self.ventana_id)
 
-        elif message.type == gst.MESSAGE_ERROR:
+        elif message.type == Gst.MESSAGE_ERROR:
             err, debug = message.parse_error()
             if PR:
                 print "ImagePlayer ERROR:"
@@ -95,7 +97,7 @@ class PlayerBin(gobject.GObject):
                 print "\t%s" % debug
 
     def __play(self):
-        self.player.set_state(gst.STATE_PLAYING)
+        self.player.set_state(Gst.STATE_PLAYING)
 
     def rotar(self, valor):
         self.stop()
@@ -109,7 +111,7 @@ class PlayerBin(gobject.GObject):
         self.video_bin.force_rotation(rot)
 
     def stop(self):
-        self.player.set_state(gst.STATE_NULL)
+        self.player.set_state(Gst.STATE_NULL)
 
     def load(self, uri):
         self.stop()
@@ -124,26 +126,26 @@ class PlayerBin(gobject.GObject):
         return False
 
 
-class Video_Out(gst.Pipeline):
+class Video_Out(Gst.Pipeline):
 
     def __init__(self, width, height):
 
-        gst.Pipeline.__init__(self)
+        Gst.Pipeline.__init__(self)
 
         self.set_name('video_out')
 
-        imagefreeze = gst.element_factory_make('imagefreeze', "imagefreeze")
-        videoconvert = gst.element_factory_make(
+        imagefreeze = Gst.element_factory_make('imagefreeze', "imagefreeze")
+        videoconvert = Gst.element_factory_make(
             'ffmpegcolorspace', 'ffmpegcolorspace')
 
-        videoflip = gst.element_factory_make('videoflip', "videoflip")
-        caps = gst.Caps(
+        videoflip = Gst.element_factory_make('videoflip', "videoflip")
+        caps = Gst.Caps(
             'video/x-raw-rgb,framerate=30/1,width=%s,height=%s' % (
             width, height))
-        filtro = gst.element_factory_make("capsfilter", "filtro")
+        filtro = Gst.element_factory_make("capsfilter", "filtro")
         filtro.set_property("caps", caps)
 
-        ximagesink = gst.element_factory_make('ximagesink', "ximagesink")
+        ximagesink = Gst.element_factory_make('ximagesink', "ximagesink")
         ximagesink.set_property("force-aspect-ratio", True)
 
         self.add(imagefreeze)
@@ -157,7 +159,7 @@ class Video_Out(gst.Pipeline):
         videoflip.link(filtro)
         filtro.link(ximagesink)
 
-        self.ghost_pad = gst.GhostPad(
+        self.ghost_pad = Gst.GhostPad(
             "sink", imagefreeze.get_static_pad("sink"))
 
         self.ghost_pad.set_target(imagefreeze.get_static_pad("sink"))

--- a/CucaraSims/JAMediaReproductor/JAMediaBins.py
+++ b/CucaraSims/JAMediaReproductor/JAMediaBins.py
@@ -5,36 +5,38 @@
 #   Flavio Danesse <fdanesse@gmail.com>
 #   Uruguay
 
-import gst
-import gobject
+import gi
+gi.require_version('Gst', '1.0')
+from gi.repository import Gst
+from gi.repository import GObject
+from gi.repository import GLib
+GLib.threads_init()
 
-gobject.threads_init()
 
-
-class JAMedia_Audio_Pipeline(gst.Pipeline):
+class JAMedia_Audio_Pipeline(Gst.Pipeline):
 
     def __init__(self):
 
-        gst.Pipeline.__init__(self)
+        Gst.Pipeline.__init__(self)
 
         self.set_name('jamedia_audio_pipeline')
 
-        convert = gst.element_factory_make("audioconvert", "convert")
-        sink = gst.element_factory_make("autoaudiosink", "sink")
+        convert = Gst.element_factory_make("audioconvert", "convert")
+        sink = Gst.element_factory_make("autoaudiosink", "sink")
 
         self.add(convert)
         self.add(sink)
 
         convert.link(sink)
 
-        self.add_pad(gst.GhostPad("sink", convert.get_static_pad("sink")))
+        self.add_pad(Gst.GhostPad("sink", convert.get_static_pad("sink")))
 
 
-class JAMedia_Video_Pipeline(gst.Pipeline):
+class JAMedia_Video_Pipeline(Gst.Pipeline):
 
     def __init__(self):
 
-        gst.Pipeline.__init__(self)
+        Gst.Pipeline.__init__(self)
 
         self.set_name('jamedia_video_pipeline')
 
@@ -46,12 +48,12 @@ class JAMedia_Video_Pipeline(gst.Pipeline):
             'gamma': 10.0,
             'rotacion': 0}
 
-        convert = gst.element_factory_make('ffmpegcolorspace', 'convert')
-        rate = gst.element_factory_make('videorate', 'rate')
-        videobalance = gst.element_factory_make('videobalance', "videobalance")
-        gamma = gst.element_factory_make('gamma', "gamma")
-        videoflip = gst.element_factory_make('videoflip', "videoflip")
-        pantalla = gst.element_factory_make('xvimagesink', "pantalla")
+        convert = Gst.element_factory_make('ffmpegcolorspace', 'convert')
+        rate = Gst.element_factory_make('videorate', 'rate')
+        videobalance = Gst.element_factory_make('videobalance', "videobalance")
+        gamma = Gst.element_factory_make('gamma', "gamma")
+        videoflip = Gst.element_factory_make('videoflip', "videoflip")
+        pantalla = Gst.element_factory_make('xvimagesink', "pantalla")
         pantalla.set_property("force-aspect-ratio", True)
 
         try:  # FIXME: xo no posee esta propiedad
@@ -73,7 +75,7 @@ class JAMedia_Video_Pipeline(gst.Pipeline):
         gamma.link(videoflip)
         videoflip.link(pantalla)
 
-        self.ghost_pad = gst.GhostPad("sink", convert.get_static_pad("sink"))
+        self.ghost_pad = Gst.GhostPad("sink", convert.get_static_pad("sink"))
         self.ghost_pad.set_target(convert.get_static_pad("sink"))
         self.add_pad(self.ghost_pad)
 

--- a/CucaraSims/JAMediaReproductor/JAMediaReproductor.py
+++ b/CucaraSims/JAMediaReproductor/JAMediaReproductor.py
@@ -6,35 +6,38 @@
 #   Uruguay
 
 import os
-import gobject
-import gst
+import gi
+from gi.repository import GObject
+from gi.repository import GLib
+gi.require_version('Gst', '1.0')
+from gi.repository import Gst
 
 from JAMediaBins import JAMedia_Audio_Pipeline
 from JAMediaBins import JAMedia_Video_Pipeline
 
 PR = False
 
-gobject.threads_init()
+GLib.threads_init()
 
 
-class JAMediaReproductor(gobject.GObject):
+class JAMediaReproductor(GObject.GObject):
 
     __gsignals__ = {
-    "endfile": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, []),
-    "estado": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, (gobject.TYPE_STRING,)),
-    "newposicion": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, (gobject.TYPE_INT,)),
-    "video": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, (gobject.TYPE_BOOLEAN,)),
-    "loading-buffer": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, (gobject.TYPE_INT, )),
+    "endfile": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, []),
+    "estado": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, (GObject.TYPE_STRING,)),
+    "newposicion": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, (GObject.TYPE_INT,)),
+    "video": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, (GObject.TYPE_BOOLEAN,)),
+    "loading-buffer": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, (GObject.TYPE_INT, )),
         }
 
     def __init__(self, ventana_id):
 
-        gobject.GObject.__init__(self)
+        GObject.GObject.__init__(self)
 
         self.nombre = "JAMediaReproductor"
 
@@ -48,7 +51,7 @@ class JAMediaReproductor(gobject.GObject):
         self.player = None
         self.bus = None
 
-        self.player = gst.element_factory_make("playbin2", "player")
+        self.player = Gst.element_factory_make("playbin2", "player")
         self.player.set_property("buffer-size", 50000)
 
         self.audio_bin = JAMedia_Audio_Pipeline()
@@ -64,25 +67,25 @@ class JAMediaReproductor(gobject.GObject):
         self.bus.connect('sync-message', self.__sync_message)
 
     def __sync_message(self, bus, message):
-        if message.type == gst.MESSAGE_ELEMENT:
+        if message.type == Gst.MESSAGE_ELEMENT:
             if message.structure.get_name() == 'prepare-xwindow-id':
                 message.src.set_xwindow_id(self.ventana_id)
 
-        elif message.type == gst.MESSAGE_STATE_CHANGED:
+        elif message.type == Gst.MESSAGE_STATE_CHANGED:
             old, new, pending = message.parse_state_changed()
 
             if self.estado != new:
                 self.estado = new
 
-                if new == gst.STATE_PLAYING:
+                if new == Gst.STATE_PLAYING:
                     self.emit("estado", "playing")
                     self.__new_handle(True)
 
-                elif new == gst.STATE_PAUSED:
+                elif new == Gst.STATE_PAUSED:
                     self.emit("estado", "paused")
                     self.__new_handle(False)
 
-                elif new == gst.STATE_NULL:
+                elif new == Gst.STATE_NULL:
                     self.emit("estado", "None")
                     self.__new_handle(False)
 
@@ -90,7 +93,7 @@ class JAMediaReproductor(gobject.GObject):
                     self.emit("estado", "paused")
                     self.__new_handle(False)
 
-        elif message.type == gst.MESSAGE_TAG:
+        elif message.type == Gst.MESSAGE_TAG:
             taglist = message.parse_tag()
             datos = taglist.keys()
             if 'video-codec' in datos:
@@ -98,10 +101,10 @@ class JAMediaReproductor(gobject.GObject):
                     self.video = True
                     self.emit("video", self.video)
 
-        elif message.type == gst.MESSAGE_LATENCY:
+        elif message.type == Gst.MESSAGE_LATENCY:
             self.player.recalculate_latency()
 
-        elif message.type == gst.MESSAGE_ERROR:
+        elif message.type == Gst.MESSAGE_ERROR:
             err, debug = message.parse_error()
             if PR:
                 print "JAMediaReproductor ERROR:"
@@ -110,11 +113,11 @@ class JAMediaReproductor(gobject.GObject):
             self.__new_handle(False)
 
     def __on_mensaje(self, bus, message):
-        if message.type == gst.MESSAGE_EOS:
+        if message.type == Gst.MESSAGE_EOS:
             self.__new_handle(False)
             self.emit("endfile")
 
-        elif message.type == gst.MESSAGE_ERROR:
+        elif message.type == Gst.MESSAGE_ERROR:
             err, debug = message.parse_error()
             if PR:
                 print "JAMediaReproductor ERROR:"
@@ -122,36 +125,36 @@ class JAMediaReproductor(gobject.GObject):
                 print "\t%s" % debug
             self.__new_handle(False)
 
-        elif message.type == gst.MESSAGE_BUFFERING:
+        elif message.type == Gst.MESSAGE_BUFFERING:
             buf = int(message.structure["buffer-percent"])
-            if buf < 100 and self.estado == gst.STATE_PLAYING:
+            if buf < 100 and self.estado == Gst.STATE_PLAYING:
                 self.emit("loading-buffer", buf)
                 self.__pause()
 
-            elif buf > 99 and self.estado != gst.STATE_PLAYING:
+            elif buf > 99 and self.estado != Gst.STATE_PLAYING:
                 self.emit("loading-buffer", buf)
                 self.__play()
 
     def __play(self):
-        self.player.set_state(gst.STATE_PLAYING)
+        self.player.set_state(Gst.STATE_PLAYING)
 
     def __pause(self):
-        self.player.set_state(gst.STATE_PAUSED)
+        self.player.set_state(Gst.STATE_PAUSED)
 
     def __new_handle(self, reset):
         if self.actualizador:
-            gobject.source_remove(self.actualizador)
+            GLib.source_remove(self.actualizador)
             self.actualizador = False
 
         if reset:
-            self.actualizador = gobject.timeout_add(500, self.__handle)
+            self.actualizador = GLib.timeout_add(500, self.__handle)
 
     def __handle(self):
         if not self.progressbar:
             return True
 
-        duracion = self.player.query_duration(gst.FORMAT_TIME)[0] / gst.SECOND
-        posicion = self.player.query_position(gst.FORMAT_TIME)[0] / gst.SECOND
+        duracion = self.player.query_duration(Gst.FORMAT_TIME)[0] / Gst.SECOND
+        posicion = self.player.query_position(Gst.FORMAT_TIME)[0] / Gst.SECOND
 
         pos = posicion * 100 / duracion
 
@@ -165,11 +168,11 @@ class JAMediaReproductor(gobject.GObject):
         return True
 
     def pause_play(self):
-        if self.estado == gst.STATE_PAUSED or self.estado == gst.STATE_NULL \
-            or self.estado == gst.STATE_READY:
+        if self.estado == Gst.STATE_PAUSED or self.estado == Gst.STATE_NULL \
+            or self.estado == Gst.STATE_READY:
             self.__play()
 
-        elif self.estado == gst.STATE_PLAYING:
+        elif self.estado == Gst.STATE_PLAYING:
             self.__pause()
 
     def rotar(self, valor):
@@ -185,7 +188,7 @@ class JAMediaReproductor(gobject.GObject):
 
     def stop(self):
         self.__new_handle(False)
-        self.player.set_state(gst.STATE_NULL)
+        self.player.set_state(Gst.STATE_NULL)
         self.emit("newposicion", 0)
 
     def load(self, uri):
@@ -204,7 +207,7 @@ class JAMediaReproductor(gobject.GObject):
             self.__play()
 
         else:
-            if gst.uri_is_valid(uri):
+            if Gst.uri_is_valid(uri):
                 self.player.set_property("uri", uri)
                 self.progressbar = False
                 self.__play()
@@ -223,11 +226,11 @@ class JAMediaReproductor(gobject.GObject):
 
         posicion = self.duracion * posicion / 100
 
-        event = gst.event_new_seek(
-            1.0, gst.FORMAT_TIME,
-            gst.SEEK_FLAG_FLUSH | gst.SEEK_FLAG_ACCURATE,
-            gst.SEEK_TYPE_SET, posicion * 1000000000,
-            gst.SEEK_TYPE_NONE, self.duracion * 1000000000)
+        event = Gst.event_new_seek(
+            1.0, Gst.FORMAT_TIME,
+            Gst.SEEK_FLAG_FLUSH | Gst.SEEK_FLAG_ACCURATE,
+            Gst.SEEK_TYPE_SET, posicion * 1000000000,
+            Gst.SEEK_TYPE_NONE, self.duracion * 1000000000)
 
         self.player.send_event(event)
 

--- a/CucaraSims/Juego.py
+++ b/CucaraSims/Juego.py
@@ -6,9 +6,10 @@
 #   Uruguay
 
 import os
-import gobject
-import pygame
 import gtk
+from gi.repository import GObject
+from gi.repository import GLib
+import pygame
 import random
 import platform
 
@@ -27,26 +28,26 @@ BASE_PATH = os.path.dirname(__file__)
 BASE_PATH = os.path.dirname(BASE_PATH)
 OLPC = 'olpc' in platform.platform()
 
-gobject.threads_init()
+GLib.threads_init()
 
 
-class CucaraSims(gobject.GObject):
+class CucaraSims(GObject.GObject):
 
     __gsignals__ = {
-    "exit": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, []),
-    "lectura": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, (gobject.TYPE_STRING, )),
-    "clear-cursor-gtk": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, []),
-    "update": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, (gobject.TYPE_PYOBJECT, )),
-    "puntos": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, (gobject.TYPE_INT, ))}
+    "exit": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, []),
+    "lectura": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, (GObject.TYPE_STRING, )),
+    "clear-cursor-gtk": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, []),
+    "update": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, (GObject.TYPE_PYOBJECT, )),
+    "puntos": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, (GObject.TYPE_INT, ))}
 
     def __init__(self):
 
-        gobject.GObject.__init__(self)
+        GObject.GObject.__init__(self)
 
         self.RESOLUCION_INICIAL = RESOLUCION_INICIAL
         self.resolucionreal = RESOLUCION_INICIAL

--- a/CucaraSims/Timer.py
+++ b/CucaraSims/Timer.py
@@ -6,18 +6,19 @@
 #   Uruguay
 
 import time
-import gobject
+from gi.repository import GObject
+from gi.repository import GLib
 
 
-class Timer(gobject.GObject):
+class Timer(GObject.GObject):
 
     __gsignals__ = {
-    "new-time": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, (gobject.TYPE_PYOBJECT, ))}
+    "new-time": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, (GObject.TYPE_PYOBJECT, ))}
 
     def __init__(self, demora):
 
-        gobject.GObject.__init__(self)
+        GObject.GObject.__init__(self)
 
         self.actualizador = False
         self.init = int(time.time())
@@ -49,10 +50,10 @@ class Timer(gobject.GObject):
 
     def new_handle(self, reset):
         if self.actualizador:
-            gobject.source_remove(self.actualizador)
+            GLib.source_remove(self.actualizador)
             self.actualizador = False
         if reset:
-            self.actualizador = gobject.timeout_add(1000, self.__handle)
+            self.actualizador = GLib.timeout_add(1000, self.__handle)
 
     def salir(self):
         self.new_handle(False)

--- a/CucaraSims/Widgets.py
+++ b/CucaraSims/Widgets.py
@@ -7,7 +7,8 @@
 
 import os
 import gtk
-import gobject
+from gi.repository import GObject
+from gi.repository import GLib
 import pygame
 from pygame.sprite import Sprite
 from JAMediaImagenes.ImagePlayer import ImagePlayer
@@ -134,7 +135,7 @@ class Visor(gtk.DrawingArea):
             self.player = ImagePlayer(self)
         elif 'video' in tipo or 'application/ogg':
             self.player = JAMediaReproductor(self.get_property('window').xid)
-        gobject.idle_add(self.player.load, self.archivo)
+        GLib.idle_add(self.player.load, self.archivo)
 
 
 class Cursor(Sprite):
@@ -297,8 +298,8 @@ class Toolbar(gtk.EventBox):
 class ToolbarEstado(gtk.EventBox):
 
     __gsignals__ = {
-    "volumen": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, (gobject.TYPE_FLOAT, ))}
+    "volumen": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, (GObject.TYPE_FLOAT, ))}
 
     def __init__(self):
 
@@ -343,8 +344,8 @@ class ToolbarEstado(gtk.EventBox):
 class ControlVolumen(gtk.VolumeButton):
 
     __gsignals__ = {
-    "volumen": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, (gobject.TYPE_FLOAT, ))}
+    "volumen": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, (GObject.TYPE_FLOAT, ))}
 
     def __init__(self):
 

--- a/Intro/Intro.py
+++ b/Intro/Intro.py
@@ -2,9 +2,10 @@
 # -*- coding: utf-8 -*-
 
 import os
-import gobject
 import pygame
 import gtk
+from gi.repository import GObject
+from gi.repository import GLib
 import platform
 
 from pygame.locals import HWSURFACE
@@ -17,20 +18,20 @@ BASE_PATH = os.path.dirname(__file__)
 BASE_PATH = os.path.dirname(BASE_PATH)
 OLPC = 'olpc' in platform.platform()
 
-gobject.threads_init()
+GLib.threads_init()
 
 
-class Intro(gobject.GObject):
+class Intro(GObject.GObject):
 
     __gsignals__ = {
-    "exit": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, []),
-    "go": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, (gobject.TYPE_STRING, ))}
+    "exit": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, []),
+    "go": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, (GObject.TYPE_STRING, ))}
 
     def __init__(self):
 
-        gobject.GObject.__init__(self)
+        GObject.GObject.__init__(self)
 
         self.RESOLUCION_INICIAL = RESOLUCION_INICIAL
         self.resolucionreal = RESOLUCION_INICIAL
@@ -78,7 +79,7 @@ class Intro(gobject.GObject):
                 while gtk.events_pending():
                     gtk.main_iteration()
                 if len(self.sprites.sprites()) < 5:
-                    gobject.idle_add(self.sprites.add,
+                    GLib.idle_add(self.sprites.add,
                         Bicho(RESOLUCION_INICIAL[0],
                         RESOLUCION_INICIAL[1]))
                 self.sprites.clear(self.ventana, self.escenario)

--- a/Main.py
+++ b/Main.py
@@ -8,7 +8,7 @@
 import os
 import sys
 import gtk
-import gobject
+from gi.repository import GLib
 
 from EventTraductor.EventTraductor import KeyPressTraduce
 from EventTraductor.EventTraductor import KeyReleaseTraduce
@@ -148,7 +148,7 @@ class Bichos(gtk.Window):
             self.widgetjuego = Escenario()
             self.widgetjuego.connect("new-size", self.__redraw)
             self.add(self.widgetjuego)
-            gobject.idle_add(self.__run_intro, self.widgetjuego)
+            GLib.idle_add(self.__run_intro, self.widgetjuego)
 
         elif valor == 2:
             self.modify_bg(gtk.STATE_NORMAL, gtk.gdk.color_parse("#ffffff"))
@@ -159,7 +159,7 @@ class Bichos(gtk.Window):
             escenario.connect("mouse-enter", self.__mouse_enter)
             self.widgetjuego = CucaraSimsWidget(escenario)
             self.add(self.widgetjuego)
-            gobject.idle_add(self.__run_cucarasims, escenario)
+            GLib.idle_add(self.__run_cucarasims, escenario)
 
         elif valor == 3:
             self.modify_bg(gtk.STATE_NORMAL, gtk.gdk.color_parse("#ffffff"))

--- a/OjosCompuestos/JAMediaImagenes/ImagePlayer.py
+++ b/OjosCompuestos/JAMediaImagenes/ImagePlayer.py
@@ -6,17 +6,18 @@
 #   Uruguay
 
 import os
-import gobject
-import gst
-
+from gi.repository import GObject
+import gi
+gi.require_version("Gst", "1.0")
+from gi.repository import Gst
 PR = False
 
 
-class ImagePlayer(gobject.GObject):
+class ImagePlayer(GObject.GObject):
 
     def __init__(self, ventana):
 
-        gobject.GObject.__init__(self)
+        GObject.GObject.__init__(self)
 
         self.ventana = ventana
         self.src_path = ""
@@ -63,17 +64,17 @@ class ImagePlayer(gobject.GObject):
             pass
 
 
-class PlayerBin(gobject.GObject):
+class PlayerBin(GObject.GObject):
 
     def __init__(self, ventana_id, width, height):
 
-        gobject.GObject.__init__(self)
+        GObject.GObject.__init__(self)
 
         self.ventana_id = ventana_id
         self.player = None
         self.bus = None
 
-        self.player = gst.element_factory_make("playbin2", "player")
+        self.player = Gst.element_factory_make("playbin2", "player")
         self.video_bin = Video_Out(width, height)
         self.player.set_property('video-sink', self.video_bin)
 
@@ -83,11 +84,11 @@ class PlayerBin(gobject.GObject):
         self.bus.connect('sync-message', self.__sync_message)
 
     def __sync_message(self, bus, message):
-        if message.type == gst.MESSAGE_ELEMENT:
+        if message.type == Gst.MESSAGE_ELEMENT:
             if message.structure.get_name() == 'prepare-xwindow-id':
                 message.src.set_xwindow_id(self.ventana_id)
 
-        elif message.type == gst.MESSAGE_ERROR:
+        elif message.type == Gst.MESSAGE_ERROR:
             err, debug = message.parse_error()
             if PR:
                 print "ImagePlayer ERROR:"
@@ -95,7 +96,7 @@ class PlayerBin(gobject.GObject):
                 print "\t%s" % debug
 
     def __play(self):
-        self.player.set_state(gst.STATE_PLAYING)
+        self.player.set_state(Gst.STATE_PLAYING)
 
     def rotar(self, valor):
         self.stop()
@@ -109,7 +110,7 @@ class PlayerBin(gobject.GObject):
         self.video_bin.force_rotation(rot)
 
     def stop(self):
-        self.player.set_state(gst.STATE_NULL)
+        self.player.set_state(Gst.STATE_NULL)
 
     def load(self, uri):
         self.stop()
@@ -124,26 +125,26 @@ class PlayerBin(gobject.GObject):
         return False
 
 
-class Video_Out(gst.Pipeline):
+class Video_Out(Gst.Pipeline):
 
     def __init__(self, width, height):
 
-        gst.Pipeline.__init__(self)
+        Gst.Pipeline.__init__(self)
 
         self.set_name('video_out')
 
-        imagefreeze = gst.element_factory_make('imagefreeze', "imagefreeze")
-        videoconvert = gst.element_factory_make(
+        imagefreeze = Gst.element_factory_make('imagefreeze', "imagefreeze")
+        videoconvert = Gst.element_factory_make(
             'ffmpegcolorspace', 'ffmpegcolorspace')
 
-        videoflip = gst.element_factory_make('videoflip', "videoflip")
-        caps = gst.Caps(
+        videoflip = Gst.element_factory_make('videoflip', "videoflip")
+        caps = Gst.Caps(
             'video/x-raw-rgb,framerate=30/1,width=%s,height=%s' % (
             width, height))
-        filtro = gst.element_factory_make("capsfilter", "filtro")
+        filtro = Gst.element_factory_make("capsfilter", "filtro")
         filtro.set_property("caps", caps)
 
-        ximagesink = gst.element_factory_make('ximagesink', "ximagesink")
+        ximagesink = Gst.element_factory_make('ximagesink', "ximagesink")
         ximagesink.set_property("force-aspect-ratio", True)
 
         self.add(imagefreeze)
@@ -157,7 +158,7 @@ class Video_Out(gst.Pipeline):
         videoflip.link(filtro)
         filtro.link(ximagesink)
 
-        self.ghost_pad = gst.GhostPad(
+        self.ghost_pad = Gst.GhostPad(
             "sink", imagefreeze.get_static_pad("sink"))
 
         self.ghost_pad.set_target(imagefreeze.get_static_pad("sink"))

--- a/OjosCompuestos/OjosCompuestos.py
+++ b/OjosCompuestos/OjosCompuestos.py
@@ -7,7 +7,7 @@
 
 import os
 import gtk
-import gobject
+from gi.repository import GLib
 from PlayerList import PlayerList
 from JAMediaImagenes.ImagePlayer import ImagePlayer
 
@@ -37,7 +37,7 @@ class OjosCompuestos(gtk.HPaned):
         self.show_all()
 
     def __load_imagenes(self, widget):
-        gobject.idle_add(self.__run)
+        GLib.idle_add(self.__run)
 
     def __run(self):
         self.player = ImagePlayer(self.pantalla)
@@ -74,4 +74,4 @@ class Dialog(gtk.Dialog):
         self.vbox.pack_start(label, True, True, 0)
         self.vbox.show_all()
 
-        gobject.timeout_add(3000, self.destroy)
+        GLib.timeout_add(3000, self.destroy)

--- a/OjosCompuestos/PlayerList.py
+++ b/OjosCompuestos/PlayerList.py
@@ -6,14 +6,15 @@
 #   Uruguay
 
 import gtk
-import gobject
+from gi.repository import GObject
+from gi.repository import GLib
 
 
 class PlayerList(gtk.Frame):
 
     __gsignals__ = {
-    "nueva-seleccion": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, (gobject.TYPE_PYOBJECT, ))}
+    "nueva-seleccion": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, (GObject.TYPE_PYOBJECT, ))}
 
     def __init__(self):
 
@@ -97,15 +98,15 @@ class PlayerList(gtk.Frame):
 class Lista(gtk.TreeView):
 
     __gsignals__ = {
-    "nueva-seleccion": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, (gobject.TYPE_PYOBJECT, ))}
+    "nueva-seleccion": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, (GObject.TYPE_PYOBJECT, ))}
 
     def __init__(self):
 
         gtk.TreeView.__init__(self, gtk.ListStore(
             gtk.gdk.Pixbuf,
-            gobject.TYPE_STRING,
-            gobject.TYPE_STRING))
+            GObject.TYPE_STRING,
+            GObject.TYPE_STRING))
 
         self.modify_bg(gtk.STATE_NORMAL, gtk.gdk.color_parse("#ffffff"))
         self.set_property("rules-hint", True)
@@ -137,7 +138,7 @@ class Lista(gtk.TreeView):
         if self.valor_select != valor:
             self.valor_select = valor
 
-            gobject.timeout_add(3, self.__select,
+            GLib.timeout_add(3, self.__select,
                 self.get_model().get_path(_iter))
 
         return True
@@ -189,7 +190,7 @@ class Lista(gtk.TreeView):
 
         self.get_model().append([pixbuf, texto, path])
         elementos.remove(elementos[0])
-        gobject.idle_add(self.__ejecutar_agregar_elemento, elementos)
+        GLib.idle_add(self.__ejecutar_agregar_elemento, elementos)
         return False
 
     def limpiar(self):
@@ -206,7 +207,7 @@ class Lista(gtk.TreeView):
         """
         self.get_toplevel().set_sensitive(False)
         self.permitir_select = False
-        gobject.idle_add(self.__ejecutar_agregar_elemento, elementos)
+        GLib.idle_add(self.__ejecutar_agregar_elemento, elementos)
 
     def seleccionar_siguiente(self, widget=None):
         modelo, _iter = self.get_selection().get_selected()

--- a/SugarBichos.py
+++ b/SugarBichos.py
@@ -8,7 +8,8 @@
 import os
 import sys
 import gtk
-import gobject
+from gi.repository import GLib
+from gi.repository import gdk
 
 from EventTraductor.EventTraductor import KeyPressTraduce
 from EventTraductor.EventTraductor import KeyReleaseTraduce
@@ -20,7 +21,7 @@ from CucaraSims.CucaraSims import CucaraSimsWidget
 from CucaraSims.Juego import CucaraSims
 from OjosCompuestos.OjosCompuestos import OjosCompuestos
 
-from sugar.activity.activity import Activity
+from sugar3.activity.activity import Activity
 
 
 class Bichos(Activity):
@@ -62,7 +63,7 @@ class Interfaz(gtk.Plug):
         if self.juego:
             KeyPressTraduce(event)
         else:
-            if gtk.gdk.keyval_name(event.keyval) == "Escape":
+            if gdk.keyval_name(event.keyval) == "Escape":
                 self.widgetjuego.salir()
                 self.switch(False, 1)
         return False
@@ -154,13 +155,13 @@ class Interfaz(gtk.Plug):
         for child in self.get_children():
             self.remove(child)
             child.destroy()
-        self.modify_bg(gtk.STATE_NORMAL, gtk.gdk.color_parse("#000000"))
+        self.modify_bg(gtk.StateType.NORMAL, gdk.color_parse("#000000"))
 
         if valor == 1:
             self.widgetjuego = Escenario()
             self.widgetjuego.connect("new-size", self.__redraw)
             self.add(self.widgetjuego)
-            gobject.idle_add(self.__run_intro, self.widgetjuego)
+            GLib.idle_add(self.__run_intro, self.widgetjuego)
 
         elif valor == 2:
             self.modify_bg(gtk.STATE_NORMAL, gtk.gdk.color_parse("#ffffff"))
@@ -171,7 +172,7 @@ class Interfaz(gtk.Plug):
             escenario.connect("mouse-enter", self.__mouse_enter)
             self.widgetjuego = CucaraSimsWidget(escenario)
             self.add(self.widgetjuego)
-            gobject.idle_add(self.__run_cucarasims, escenario)
+            GLib.idle_add(self.__run_cucarasims, escenario)
 
         elif valor == 3:
             self.modify_bg(gtk.STATE_NORMAL, gtk.gdk.color_parse("#ffffff"))

--- a/Widgets.py
+++ b/Widgets.py
@@ -2,7 +2,8 @@
 # -*- coding: utf-8 -*-
 
 import gtk
-import gobject
+from gi.repository import GObject
+from gi.repository import gdk
 
 from EventTraductor.EventTraductor import MousemotionTraduce
 from EventTraductor.EventTraductor import Traduce_button_press_event
@@ -12,24 +13,24 @@ from EventTraductor.EventTraductor import Traduce_button_release_event
 class Escenario(gtk.DrawingArea):
 
     __gsignals__ = {
-    "new-size": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, (gobject.TYPE_PYOBJECT, )),
-    "mouse-enter": (gobject.SIGNAL_RUN_LAST,
-        gobject.TYPE_NONE, (gobject.TYPE_BOOLEAN, ))}
+    "new-size": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, (GObject.TYPE_PYOBJECT, )),
+    "mouse-enter": (GObject.SIGNAL_RUN_LAST,
+        GObject.TYPE_NONE, (GObject.TYPE_BOOLEAN, ))}
 
     def __init__(self):
 
         gtk.DrawingArea.__init__(self)
 
-        self.modify_bg(gtk.STATE_NORMAL, gtk.gdk.color_parse("#000000"))
+        self.modify_bg(gtk.StateType.NORMAL, gdk.color_parse("#000000"))
 
-        self.set_events(gtk.gdk.EXPOSE |
-            #gtk.gdk.KEY_PRESS | gtk.gdk.KEY_RELEASE |
-            #gtk.gdk.KEY_RELEASE_MASK | gtk.gdk.KEY_PRESS_MASK |
-            gtk.gdk.POINTER_MOTION_MASK | gtk.gdk.POINTER_MOTION_HINT_MASK |
-            gtk.gdk.BUTTON_MOTION_MASK | gtk.gdk.BUTTON_PRESS_MASK |
-            gtk.gdk.BUTTON_RELEASE_MASK | gtk.gdk.LEAVE_NOTIFY_MASK
-            | gtk.gdk.ENTER_NOTIFY_MASK)
+        self.set_events(gdk.EventType.EXPOSE |
+            #gdk.KEY_PRESS | gtk.gdk.KEY_RELEASE |
+            #gdk.KEY_RELEASE_MASK | gdk.KEY_PRESS_MASK |
+            gdk.EventMask.POINTER_MOTION_MASK | gdk.EventMask.POINTER_MOTION_HINT_MASK |
+            gdk.EventMask.BUTTON_MOTION_MASK | gdk.EventMask.BUTTON_PRESS_MASK |
+            gdk.EventMask.BUTTON_RELEASE_MASK | gdk.EventMask.LEAVE_NOTIFY_MASK
+            | gdk.EventMask.ENTER_NOTIFY_MASK)
 
         self.connect("size-allocate", self.__size_request)
         self.connect("expose-event", self.__redraw)


### PR DESCRIPTION
### Explanation
Fixes #2. This PR GObject based methods to GLib. 

### Reason
Thousands of PyGIDeprecationWarning occur in shell.log and activity logs when using PyGObject development releases, because of our use of GObject instead of GLib for certain methods.

### TODO
- [ ] Test (Couldn't because gtk isn't updated)
