### PR TITLE
Port GObject based methods to GLib

### DIFF
--- a/CantaBichos/CantaBichos.py
+++ b/CantaBichos/CantaBichos.py
@@ -5,6 +5,7 @@ import os
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GdkPixbuf
+from gi.repository import GLib
 from gi.repository import GObject
 
 from player import Player
@@ -45,7 +46,7 @@ class CantaBichos(Gtk.Table):
         self.show_all()
 
     def __realize(self, widget):
-        GObject.idle_add(self.__dialog_run)
+        GLib.idle_add(self.__dialog_run)
 
     def __dialog_run(self):
         dialog = Dialog(parent=self.get_toplevel(),
@@ -130,13 +131,13 @@ class Button(Gtk.EventBox):
 
     def __size_request(self, widget, event):
         rect = self.get_allocation()
-        GObject.idle_add(self.imagen.set_from_pixbuf,
+        GLib.idle_add(self.imagen.set_from_pixbuf,
             GdkPixbuf.Pixbuf.new_from_file_at_size(
             self.image_path, rect.width, -1))
 
     def __draw_cb(self, widget, event):
         rect = self.get_allocation()
-        GObject.idle_add(self.imagen.set_from_pixbuf,
+        GLib.idle_add(self.imagen.set_from_pixbuf,
             GdkPixbuf.Pixbuf.new_from_file_at_size(
             self.image_path, rect.width, -1))
 
@@ -160,4 +161,4 @@ class Dialog(Gtk.Dialog):
         self.vbox.pack_start(label, True, True, 0)
         self.vbox.show_all()
 
-        GObject.timeout_add(3000, self.destroy)
+        GLib.timeout_add(3000, self.destroy)

--- a/CantaBichos/player.py
+++ b/CantaBichos/player.py
@@ -8,10 +8,11 @@
 import os
 import gi
 gi.require_version('Gst', '1.0')
+from gi.repository import GLib
 from gi.repository import GObject
 from gi.repository import Gst
 
-GObject.threads_init()
+GLib.threads_init()
 Gst.init(None)
 
 

--- a/CucaraSims/CucaraSims.py
+++ b/CucaraSims/CucaraSims.py
@@ -9,6 +9,7 @@ import os
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GdkPixbuf
+from gi.repository import GLib
 from gi.repository import GObject
 
 from Widgets import Widget_Leccion
@@ -59,7 +60,7 @@ class CucaraSimsWidget(Gtk.HPaned):
         self.cursor_root = False
         self.cursor_tipo = False
 
-        GObject.idle_add(self.__config_cursors)
+        GLib.idle_add(self.__config_cursors)
 
     def __volumen_changed(self, widget, valor):
         self.emit('volumen', valor)

--- a/CucaraSims/JAMediaReproductor/JAMediaBins.py
+++ b/CucaraSims/JAMediaReproductor/JAMediaBins.py
@@ -6,9 +6,9 @@
 #   Uruguay
 
 from gi.repository import Gst
-from gi.repository import GObject
+from gi.repository import GLib
 
-GObject.threads_init()
+GLib.threads_init()
 
 
 class JAMedia_Audio_Pipeline(Gst.Pipeline):

--- a/CucaraSims/JAMediaReproductor/JAMediaReproductor.py
+++ b/CucaraSims/JAMediaReproductor/JAMediaReproductor.py
@@ -6,6 +6,7 @@
 #   Uruguay
 
 import os
+from gi.repository import GLib
 from gi.repository import GObject
 from gi.repository import Gst
 
@@ -14,7 +15,7 @@ from JAMediaBins import JAMedia_Video_Pipeline
 
 PR = False
 
-GObject.threads_init()
+GLib.threads_init()
 
 
 class JAMediaReproductor(GObject.GObject):
@@ -140,11 +141,11 @@ class JAMediaReproductor(GObject.GObject):
 
     def __new_handle(self, reset):
         if self.actualizador:
-            GObject.source_remove(self.actualizador)
+            GLib.source_remove(self.actualizador)
             self.actualizador = False
 
         if reset:
-            self.actualizador = GObject.timeout_add(500, self.__handle)
+            self.actualizador = GLib.timeout_add(500, self.__handle)
 
     def __handle(self):
         if not self.progressbar:

--- a/CucaraSims/Juego.py
+++ b/CucaraSims/Juego.py
@@ -6,6 +6,7 @@
 #   Uruguay
 
 import os
+from gi.repository import GLib
 from gi.repository import GObject
 import pygame
 from gi.repository import Gtk
@@ -27,7 +28,7 @@ BASE_PATH = os.path.dirname(__file__)
 BASE_PATH = os.path.dirname(BASE_PATH)
 OLPC = 'olpc' in platform.platform()
 
-GObject.threads_init()
+GLib.threads_init()
 
 
 class CucaraSims(GObject.GObject):

--- a/CucaraSims/Timer.py
+++ b/CucaraSims/Timer.py
@@ -6,6 +6,7 @@
 #   Uruguay
 
 import time
+from gi.repository import GLib
 from gi.repository import GObject
 
 
@@ -49,10 +50,10 @@ class Timer(GObject.GObject):
 
     def new_handle(self, reset):
         if self.actualizador:
-            GObject.source_remove(self.actualizador)
+            GLib.source_remove(self.actualizador)
             self.actualizador = False
         if reset:
-            self.actualizador = GObject.timeout_add(1000, self.__handle)
+            self.actualizador = GLib.timeout_add(1000, self.__handle)
 
     def salir(self):
         self.new_handle(False)

--- a/CucaraSims/Widgets.py
+++ b/CucaraSims/Widgets.py
@@ -8,6 +8,7 @@
 import os
 from gi.repository import Gtk
 from gi.repository import Gdk
+from gi.repository import GLib
 from gi.repository import GObject
 from gi.repository import GdkPixbuf
 import pygame
@@ -140,7 +141,7 @@ class Visor(Gtk.DrawingArea):
             self.player = ImagePlayer(self)
         elif 'video' in tipo or 'application/ogg':
             self.player = JAMediaReproductor(self.get_property('window').get_xid())
-        GObject.idle_add(self.player.load, self.archivo)
+        GLib.idle_add(self.player.load, self.archivo)
 
 
 class Cursor(Sprite):

--- a/Intro/Intro.py
+++ b/Intro/Intro.py
@@ -3,6 +3,7 @@
 
 import os
 from gi.repository import GObject
+from gi.repository import GLib
 import pygame
 from gi.repository import Gtk
 import platform
@@ -17,7 +18,7 @@ BASE_PATH = os.path.dirname(__file__)
 BASE_PATH = os.path.dirname(BASE_PATH)
 OLPC = 'olpc' in platform.platform()
 
-GObject.threads_init()
+GLib.threads_init()
 
 
 class Intro(GObject.GObject):
@@ -78,7 +79,7 @@ class Intro(GObject.GObject):
                 while Gtk.events_pending():
                     Gtk.main_iteration()
                 if len(self.sprites.sprites()) < 5:
-                    GObject.idle_add(self.sprites.add,
+                    GLib.idle_add(self.sprites.add,
                         Bicho(RESOLUCION_INICIAL[0],
                         RESOLUCION_INICIAL[1]))
                 self.sprites.clear(self.ventana, self.escenario)

--- a/Main.py
+++ b/Main.py
@@ -8,6 +8,7 @@
 import os
 import sys
 from gi.repository import Gtk
+from gi.repository import GLib
 from gi.repository import GObject
 
 from EventTraductor.EventTraductor import KeyPressTraduce
@@ -148,7 +149,7 @@ class Bichos(Gtk.Window):
             self.widgetjuego = Escenario()
             self.widgetjuego.connect("new-size", self.__redraw)
             self.add(self.widgetjuego)
-            GObject.idle_add(self.__run_intro, self.widgetjuego)
+            GLib.idle_add(self.__run_intro, self.widgetjuego)
 
         elif valor == 2:
             self.override_background_color3(Gtk.StateType.NORMAL, Gdk.color_parse("#ffffff"))
@@ -159,7 +160,7 @@ class Bichos(Gtk.Window):
             escenario.connect("mouse-enter", self.__mouse_enter)
             self.widgetjuego = CucaraSimsWidget(escenario)
             self.add(self.widgetjuego)
-            GObject.idle_add(self.__run_cucarasims, escenario)
+            GLib.idle_add(self.__run_cucarasims, escenario)
 
         elif valor == 3:
             self.override_background_color(Gtk.StateType.NORMAL, Gdk.color_parse("#ffffff"))

--- a/OjosCompuestos/OjosCompuestos.py
+++ b/OjosCompuestos/OjosCompuestos.py
@@ -8,6 +8,7 @@
 import os
 from gi.repository import Gtk
 from gi.repository import Gdk
+from gi.repository import GLib
 from gi.repository import GObject
 from PlayerList import PlayerList
 from JAMediaImagenes.ImagePlayer import ImagePlayer
@@ -42,7 +43,7 @@ class OjosCompuestos(Gtk.HPaned):
         self.show_all()
 
     def __load_imagenes(self, widget):
-        GObject.idle_add(self.__run)
+        GLib.idle_add(self.__run)
 
     def __run(self):
         self.player = ImagePlayer(self.pantalla)
@@ -79,4 +80,4 @@ class Dialog(Gtk.Dialog):
         self.vbox.pack_start(label, True, True, 0)
         self.vbox.show_all()
 
-        GObject.timeout_add(3000, self.destroy)
+        GLib.timeout_add(3000, self.destroy)

--- a/OjosCompuestos/PlayerList.py
+++ b/OjosCompuestos/PlayerList.py
@@ -8,6 +8,7 @@
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GdkPixbuf
+from gi.repository import GLib
 from gi.repository import GObject
 
 def color_parser(color):
@@ -143,7 +144,7 @@ class Lista(Gtk.TreeView):
         if self.valor_select != valor:
             self.valor_select = valor
 
-            GObject.timeout_add(3, self.__select,
+            GLib.timeout_add(3, self.__select,
                 self.get_model().get_path(_iter))
 
         return True
@@ -195,7 +196,7 @@ class Lista(Gtk.TreeView):
 
         self.get_model().append([pixbuf, texto, path])
         elementos.remove(elementos[0])
-        GObject.idle_add(self.__ejecutar_agregar_elemento, elementos)
+        GLib.idle_add(self.__ejecutar_agregar_elemento, elementos)
         return False
 
     def limpiar(self):
@@ -212,7 +213,7 @@ class Lista(Gtk.TreeView):
         """
         self.get_toplevel().set_sensitive(False)
         self.permitir_select = False
-        GObject.idle_add(self.__ejecutar_agregar_elemento, elementos)
+        GLib.idle_add(self.__ejecutar_agregar_elemento, elementos)
 
     def seleccionar_siguiente(self, widget=None):
         modelo, _iter = self.get_selection().get_selected()

--- a/SugarBichos.py
+++ b/SugarBichos.py
@@ -10,6 +10,7 @@ import sys
 import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
+from gi.repository import GLib
 from gi.repository import GObject
 from gi.repository import Gdk
 
@@ -164,7 +165,7 @@ class Interfaz(Gtk.Plug):
             self.widgetjuego = Escenario()
             self.widgetjuego.connect("new-size", self.__redraw)
             self.add(self.widgetjuego)
-            GObject.idle_add(self.__run_intro, self.widgetjuego)
+            GLib.idle_add(self.__run_intro, self.widgetjuego)
 
         elif valor == 2:
             self.override_background_color(Gtk.StateType.NORMAL, color_parser("#ffffff"))
@@ -175,7 +176,7 @@ class Interfaz(Gtk.Plug):
             escenario.connect("mouse-enter", self.__mouse_enter)
             self.widgetjuego = CucaraSimsWidget(escenario)
             self.add(self.widgetjuego)
-            GObject.idle_add(self.__run_cucarasims, escenario)
+            GLib.idle_add(self.__run_cucarasims, escenario)
 
         elif valor == 3:
             self.override_background_color(Gtk.StateType.NORMAL, color_parser("#ffffff"))


### PR DESCRIPTION
### Explanation
Fix #2. This PR ports GObject based methods to GLib. 

### Reason
Thousands of PyGIDeprecationWarning occur in shell.log and activity logs when using PyGObject development releases, because of our use of GObject instead of GLib for certain methods.

### Test result
No error related to the port from GObject to GLib. 
```
tonadev@TDPC:~/Documents/Work/OpenSource/code_in/sugarlabs/bichos-activity$ sugar-activity

(sugar-activity:3193): Gtk-WARNING **: 14:56:57.878: Theme parsing error: gtk-widgets.css:16:32: The style property GtkExpander:expander-size is deprecated and shouldn't be used anymore. It will be removed in a future version

(sugar-activity:3193): Gtk-WARNING **: 14:56:57.878: Theme parsing error: gtk-widgets.css:17:35: The style property GtkExpander:expander-spacing is deprecated and shouldn't be used anymore. It will be removed in a future version
Corriendo Intro . . .
Corriendo CucaraSims . . .

(sugar-activity:3193): Gtk-WARNING **: 14:57:07.663: Attempting to add a widget with type CucaraSims+Widgets+Widget_Leccion to a SugarBichos+Bichos, but as a GtkBin subclass a SugarBichos+Bichos can only contain one widget at a time; it already contains a widget of type GtkVBox
Gtk-Message: 14:57:07.945: GtkDialog mapped without a transient parent. This is discouraged.
Corriendo Intro . . .
Corriendo Canta Bichos . . .

(sugar-activity:3193): Gtk-WARNING **: 14:57:14.341: Attempting to add a widget with type CantaBichos+CantaBichos+Dialog to a SugarBichos+Bichos, but as a GtkBin subclass a SugarBichos+Bichos can only contain one widget at a time; it already contains a widget of type GtkVBox
Corriendo Intro . . .
```
```
tonadev@TDPC:~/Documents/Work/OpenSource/code_in/sugarlabs/bichos-activity$ sugar-activity

(sugar-activity:3243): Gtk-WARNING **: 14:57:28.144: Theme parsing error: gtk-widgets.css:16:32: The style property GtkExpander:expander-size is deprecated and shouldn't be used anymore. It will be removed in a future version

(sugar-activity:3243): Gtk-WARNING **: 14:57:28.144: Theme parsing error: gtk-widgets.css:17:35: The style property GtkExpander:expander-spacing is deprecated and shouldn't be used anymore. It will be removed in a future version
Corriendo Intro . . .
Corriendo Ojos Compuestos . . .

(sugar-activity:3243): Gtk-WARNING **: 14:57:30.449: Attempting to add a widget with type OjosCompuestos+OjosCompuestos+Dialog to a SugarBichos+Bichos, but as a GtkBin subclass a SugarBichos+Bichos can only contain one widget at a time; it already contains a widget of type GtkVBox
Gtk-Message: 14:57:30.469: GtkDialog mapped without a transient parent. This is discouraged.
Corriendo Intro . . .

```
